### PR TITLE
solve disapear points bug

### DIFF
--- a/lib/scrawl/scrawl_painter.dart
+++ b/lib/scrawl/scrawl_painter.dart
@@ -38,7 +38,7 @@ class ScrawlPainter extends CustomPainter {
       _linePaint..strokeWidth = points[i].strokeWidth;
       List<Offset> curPoints = points[i].points;
       if (curPoints == null || curPoints.length == 0) {
-        break;
+        continue;
       }
       for (int i = 0; i < curPoints.length - 1; i++) {
         if (curPoints[i] != null && curPoints[i + 1] != null)


### PR DESCRIPTION
Solve the bug when the user only click screen once (points size is zero at such case), the app will never update the following lines.

Solved by replacing the previous break to continue in the loop of painting function.